### PR TITLE
novnc: Fix #13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ define rootfs
 
 	cp --recursive --preserve=timestamps --backup --suffix=.pacnew rootfs/* $(BUILDDIR)/
 
-fakechroot -- fakeroot -- chroot $(BUILDDIR) update-ca-trust
+  fakechroot -- fakeroot -- chroot $(BUILDDIR) update-ca-trust
 	fakechroot -- fakeroot -- chroot $(BUILDDIR) locale-gen
 	fakechroot -- fakeroot -- chroot $(BUILDDIR) sh -c 'pacman-key --init && pacman-key --populate archlinux blackarch && bash -c "rm -rf etc/pacman.d/gnupg/{openpgp-revocs.d/,private-keys-v1.d/,pubring.gpg~,gnupg.S.}*"'
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 Official BlackArch Linux docker images. If you find a problem, please report it [here](https://github.com/BlackArch/blackarch-docker).
 
 * **Maintainers:** BlackArch Linux developer [Stefan Venz](https://github.com/ikstream).
-* **Support:** IRC  [irc://irc.blackarch.org:1337/blackarch](irc://irc.blackarch.org:1337/blackarch).
+* **Support:** [Matrix](https://matrix.to/#/#BlackArch:matrix.org).
 
 ## What is BlackArch?
 

--- a/blackarch-novnc/Dockerfile
+++ b/blackarch-novnc/Dockerfile
@@ -14,13 +14,14 @@ FROM blackarchlinux/blackarch:latest
 # hostapd-wpe needs make, but it's not a dep because it's assumed to be installed despite not being a dep
 RUN pacman -Syu --noconfirm make && \
     # Install packages
-    pacman -Syu --noconfirm openssh vim tmux screen supervisor iw man mlocate pciutils less bash-completion novnc \
+    pacman -Syu --noconfirm openssh git vim tmux screen supervisor iw man mlocate pciutils less bash-completion novnc \
     xorg-server-xvfb x11vnc xfce4 xfce4-goodies xfce4-power-manager blackarch-config-xfce blackarch-menus blackarch-wallpaper \
     blackarch-config-cursor blackarch-config-icons blackarch-config-zsh ttf-liberation && \
 # Point wallpaper to the right files
     sed -i 's/backgrounds\/blackarch.png/blackarch\/wallpaper.png/g' /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml && \
 # Copy BlackArch configs
     cp -r /etc/skel/. /root/. && \
+    rm -f /usr/bin/websockify && \
     echo 'root:blackarch' | chpasswd && \
     echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 


### PR DESCRIPTION
novnc checks for websockify/run which is not present in BlackArch, but websockify is the executable.
by removing the executable novnc clones the websockify repo and the check is successful