### PR TITLE
temporarily(?) fix keys during docker image creation

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,8 +2,6 @@ FROM scratch
 ADD TEMPLATE_ROOTFS_FILE /
 ENV LANG=en_US.UTF-8
 # Ensure keys are up to date
-RUN rm -rf /etc/pacman.d/gnupg && \
-    pacman-key --init && \
-    pacman-key --populate archlinux && \
-    pacman-key --update --keyserver kerserver.ubuntu.com
+RUN pacman-key --init && \
+    pacman -Syu --noconfirm archlinux-keyring
 CMD ["/usr/bin/bash"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,9 @@
 FROM scratch
 ADD TEMPLATE_ROOTFS_FILE /
 ENV LANG=en_US.UTF-8
+# Ensure keys are up to date
+RUN rm -rf /etc/pacman.d/gnupg && \
+    pacman-key --init && \
+    pacman-key --populate archlinux && \
+    pacman-key --update --keyserver kerserver.ubuntu.com
 CMD ["/usr/bin/bash"]


### PR DESCRIPTION
I don't have the ROOTFS_FILE to test this with, so I tested with your published docker image and it fails in this way:
```
0.305 gpg: /etc/pacman.d/gnupg/trustdb.gpg: trustdb created
0.305 gpg: no ultimately trusted keys found
0.337 gpg: starting migration from earlier GnuPG versions
0.341 gpg: porting secret keys from '/etc/pacman.d/gnupg/secring.gpg' to gpg-agent
0.341 gpg: migration succeeded
0.343 ==> Generating pacman master key. This may take some time.
0.345 gpg: Generating pacman keyring master key...
1.206 gpg: directory '/etc/pacman.d/gnupg/openpgp-revocs.d' created
1.221 gpg: revocation certificate stored as '/etc/pacman.d/gnupg/openpgp-revocs.d/349928134542226066DD352CACBF1E04651D51D5.rev'
1.221 gpg: Done
1.223 ==> Updating trust database...
1.225 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
1.225 gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
1.240 ==> Appending keys from archlinux.gpg...
3.256 ==> Locally signing trusted keys in keyring...
7.073   -> Locally signed 6 keys.
7.074 ==> Importing owner trust values...
7.076 gpg: setting ownertrust to 4
7.076 gpg: setting ownertrust to 4
7.076 gpg: setting ownertrust to 4
7.076 gpg: setting ownertrust to 4
7.076 gpg: inserting ownertrust of 4
7.076 gpg: setting ownertrust to 4
7.077 ==> Disabling revoked keys in keyring...
7.259   -> Disabled 41 keys.
7.260 ==> Updating trust database...
7.804 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
7.820 gpg: depth: 0  valid:   1  signed:   6  trust: 0-, 0q, 0n, 0m, 0f, 1u
7.833 gpg: depth: 1  valid:   6  signed:  94  trust: 0-, 0q, 0n, 6m, 0f, 0u
7.845 gpg: depth: 2  valid:  72  signed:  26  trust: 72-, 0q, 0n, 0m, 0f, 0u
7.845 gpg: next trustdb check due at 2024-01-21
7.855 ==> Updating trust database...
7.858 gpg: next trustdb check due at 2024-01-21
7.863 :: Synchronizing package databases...
12.93  core downloading...
12.93  extra downloading...
12.93  multilib downloading...
12.93  blackarch downloading...
12.97 error: blackarch: key "F9A6E68A711354D84A9B91637533BAFE69A25079" is unknown
12.97 :: Import PGP key F9A6E68A711354D84A9B91637533BAFE69A25079? [Y/n] error: blackarch: signature from "Levon 'noptrix' Kayan (BlackArch Developer) <noptrix@nullsecurity.net>" is unknown trust
14.60 error: failed to synchronize all databases (invalid or corrupted database (PGP signature))
```
If I am ever so slightly more polite and don't `rm -rf /etc/pacman.d/gnupg` it fails in a slightly different way:
```
 > [2/6] RUN     pacman-key --init &&     pacman-key --populate archlinux &&     pacman-key --update --keyserver kerserver.ubuntu.com &&     pacman -Syu --noconfirm vim &&     pacman -R --noconfirm xfce4-power-manager &&     rm -r /etc/hostapd-wpe/certs/* &&     sed -i 's/backgrounds\/blackarch.png/blackarch\/wallpaper.png/g' /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml &&     cp -r /etc/skel/. /root/. &&     pacman -Scc <<< Y <<< Y:                                                                                                             
0.344 gpg: checking the trustdb                                                                                                                                                               
0.837 gpg: marginals needed: 3  completes needed: 1  trust model: pgp                                                                                                                         
0.851 gpg: depth: 0  valid:   1  signed:  10  trust: 0-, 0q, 0n, 0m, 0f, 1u
0.862 gpg: depth: 1  valid:  10  signed:  97  trust: 0-, 0q, 0n, 10m, 0f, 0u
0.873 gpg: depth: 2  valid:  75  signed:  26  trust: 75-, 0q, 0n, 0m, 0f, 0u
0.873 gpg: next trustdb check due at 2024-01-21
0.885 ==> Generating pacman master key. This may take some time.
0.887 gpg: Generating pacman keyring master key...
1.790 gpg: revocation certificate stored as '/etc/pacman.d/gnupg/openpgp-revocs.d/ACF807BFD20928EC7ACAE9F1A5F58F4B96DB498F.rev'
1.790 gpg: Done
1.792 ==> Updating trust database...
2.330 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
2.345 gpg: depth: 0  valid:   2  signed:  10  trust: 0-, 0q, 0n, 0m, 0f, 2u
2.357 gpg: depth: 1  valid:  10  signed:  97  trust: 0-, 0q, 0n, 10m, 0f, 0u
2.368 gpg: depth: 2  valid:  75  signed:  26  trust: 75-, 0q, 0n, 0m, 0f, 0u
2.368 gpg: next trustdb check due at 2024-01-21
2.390 ==> Appending keys from archlinux.gpg...
3.599 ==> Locally signing trusted keys in keyring...
8.056   -> Locally signed 6 keys.
8.057 ==> Importing owner trust values...
8.060 ==> Updating trust database...
8.548 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
8.561 gpg: depth: 0  valid:   2  signed:  10  trust: 0-, 0q, 0n, 0m, 0f, 2u
8.573 gpg: depth: 1  valid:  10  signed:  97  trust: 0-, 0q, 0n, 10m, 0f, 0u
8.584 gpg: depth: 2  valid:  75  signed:  26  trust: 75-, 0q, 0n, 0m, 0f, 0u
8.584 gpg: next trustdb check due at 2024-01-21
8.594 ==> Updating trust database...
8.596 gpg: next trustdb check due at 2024-01-21
8.601 :: Synchronizing package databases...
12.78  core downloading...
12.78  extra downloading...
12.78  multilib downloading...
12.78  blackarch downloading...
12.92 :: Starting full system upgrade...
12.96 resolving dependencies...
12.96 looking for conflicting packages...
12.96 
12.96 Package (30)                  Old Version  New Version            Net Change  Download Size
12.96 
12.96 core/archlinux-keyring        20231113-1   20231222-1               0.02 MiB       1.16 MiB
12.96 core/ca-certificates-mozilla  3.95-1       3.96.1-1                 0.00 MiB       0.36 MiB
12.96 core/curl                     8.4.0-2      8.5.0-1                  0.03 MiB       1.21 MiB
12.96 core/glib2                    2.78.1-1     2.78.3-1                 0.00 MiB       3.82 MiB
12.96 core/gnupg                    2.2.41-2     2.4.3-2                  0.87 MiB       2.65 MiB
12.96 core/gpgme                    1.23.1-1     1.23.2-1                 0.00 MiB       0.47 MiB
12.96 core/gpm                                   1.20.7.r38.ge82d1a6-5    0.40 MiB       0.14 MiB
12.96 core/hwdata                   0.376-1      0.377-1                  0.04 MiB       1.57 MiB
12.96 core/icu                      73.2-2       74.2-1                  -1.10 MiB      11.13 MiB
12.96 core/iputils                  20221126-2   20231222-2               0.06 MiB       0.12 MiB
12.96 core/kbd                      2.6.3-1      2.6.4-1                  0.00 MiB       1.25 MiB
12.96 core/krb5                     1.20.1-2     1.21.2-2                 0.30 MiB       1.28 MiB
12.96 core/libbpf                   1.2.2-1      1.3.0-1                  0.03 MiB       0.24 MiB
12.96 core/libcap                   2.69-2       2.69-3                   0.04 MiB       0.68 MiB
12.96 core/libcap-ng                0.8.3-2      0.8.4-1                  0.00 MiB       0.04 MiB
12.96 core/libnl                    3.8.0-1      3.9.0-1                  0.00 MiB       0.41 MiB
12.96 core/libseccomp               2.5.4-2      2.5.5-1                  0.00 MiB       0.09 MiB
12.96 core/libsecret                0.21.1-1     0.21.2-1                 0.00 MiB       0.19 MiB
12.96 core/libxml2                  2.12.1-1     2.12.3-1                 0.00 MiB       0.82 MiB
12.96 core/licenses                 20231011-1   20231215-1               0.00 MiB       0.11 MiB
12.96 core/openssl                  3.1.4-1      3.2.0-1                  0.72 MiB       4.90 MiB
12.96 core/sqlite                   3.44.1-1     3.44.2-2                 0.08 MiB       1.63 MiB
12.96 core/systemd                  254.6-2      255.2-1                  1.35 MiB       8.09 MiB
12.96 core/systemd-libs             254.6-2      255.2-1                  0.06 MiB       1.08 MiB
12.96 core/systemd-sysvcompat       254.6-2      255.2-1                  0.00 MiB       0.01 MiB
12.96 core/tzdata                   2023c-2      2023d-1                 -0.05 MiB       0.38 MiB
12.96 core/util-linux               2.39.2-2     2.39.3-1                 0.66 MiB       2.77 MiB
12.96 core/util-linux-libs          2.39.2-2     2.39.3-1                 0.00 MiB       0.44 MiB
12.96 extra/vim-runtime                          9.0.2167-1              35.61 MiB       6.89 MiB
12.96 extra/vim                                  9.0.2167-1               4.89 MiB       2.18 MiB
12.96 
12.96 Total Download Size:    56.09 MiB
12.96 Total Installed Size:  220.58 MiB
12.96 Net Upgrade Size:       44.03 MiB
12.96 
12.96 :: Proceed with installation? [Y/n] 
12.96 :: Retrieving packages...
18.22  icu-74.2-1-x86_64 downloading...
18.22  systemd-255.2-1-x86_64 downloading...
18.22  vim-runtime-9.0.2167-1-x86_64 downloading...
18.22  openssl-3.2.0-1-x86_64 downloading...
18.22  glib2-2.78.3-1-x86_64 downloading...
18.22  util-linux-2.39.3-1-x86_64 downloading...
18.22  gnupg-2.4.3-2-x86_64 downloading...
18.22  vim-9.0.2167-1-x86_64 downloading...
18.22  sqlite-3.44.2-2-x86_64 downloading...
18.22  hwdata-0.377-1-any downloading...
18.22  krb5-1.21.2-2-x86_64 downloading...
18.22  kbd-2.6.4-1-x86_64 downloading...
18.22  curl-8.5.0-1-x86_64 downloading...
18.22  archlinux-keyring-20231222-1-any downloading...
18.22  systemd-libs-255.2-1-x86_64 downloading...
18.22  libxml2-2.12.3-1-x86_64 downloading...
18.22  libcap-2.69-3-x86_64 downloading...
18.22  gpgme-1.23.2-1-x86_64 downloading...
18.22  util-linux-libs-2.39.3-1-x86_64 downloading...
18.22  libnl-3.9.0-1-x86_64 downloading...
18.22  tzdata-2023d-1-x86_64 downloading...
18.22  ca-certificates-mozilla-3.96.1-1-x86_64 downloading...
18.22  libbpf-1.3.0-1-x86_64 downloading...
18.22  libsecret-0.21.2-1-x86_64 downloading...
18.22  gpm-1.20.7.r38.ge82d1a6-5-x86_64 downloading...
18.22  iputils-20231222-2-x86_64 downloading...
18.22  licenses-20231215-1-any downloading...
18.22  libseccomp-2.5.5-1-x86_64 downloading...
18.22  libcap-ng-0.8.4-1-x86_64 downloading...
18.22  systemd-sysvcompat-255.2-1-x86_64 downloading...
18.22 checking keyring...
18.29 checking package integrity...
18.84 :: File /var/cache/pacman/pkg/vim-runtime-9.0.2167-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
18.84 Do you want to delete it? [Y/n] error: vim-runtime: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust
18.84 
18.84 :: File /var/cache/pacman/pkg/vim-9.0.2167-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
18.84 Do you want to delete it? [Y/n] error: vim: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust
18.84 error: failed to commit transaction (invalid or corrupted package)
18.87 
18.87 Errors occurred, no packages were upgraded.
```
Since the suggested `rm -rf /etc/pacman.d/gnupg` broke things, and the suggested `pacman-key --populate archlinux && pacman-key --update --keyserver kerserver.ubuntu.com` didn't fix them, I have updated this PR to my fix which does work.