### PR TITLE
Remove archlinux and blackarch from pacman-key --populate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ define rootfs
 
   fakechroot -- fakeroot -- chroot $(BUILDDIR) update-ca-trust
 	fakechroot -- fakeroot -- chroot $(BUILDDIR) locale-gen
-	fakechroot -- fakeroot -- chroot $(BUILDDIR) sh -c 'pacman-key --init && pacman-key --populate archlinux blackarch && bash -c "rm -rf etc/pacman.d/gnupg/{openpgp-revocs.d/,private-keys-v1.d/,pubring.gpg~,gnupg.S.}*"'
+	fakechroot -- fakeroot -- chroot $(BUILDDIR) sh -c 'pacman-key --init && pacman-key --populate && bash -c "rm -rf etc/pacman.d/gnupg/{openpgp-revocs.d/,private-keys-v1.d/,pubring.gpg~,gnupg.S.}*"'
   echo 'allow-weak-key-signatures' >> $(BUILDDIR)/etc/pacman.d/gnupg/gpg.conf
 
 	# add system users


### PR DESCRIPTION
Useless keeping `archlinux blackarch` in `pacman-key --populate`.

Just run `--populate` command in order to populate all installed keys to make the system consistent.